### PR TITLE
Enh declare stream

### DIFF
--- a/bluesky/bundlers.py
+++ b/bluesky/bundlers.py
@@ -24,7 +24,7 @@ ObjDict = Dict[Any, Dict[str, T]]
 
 
 class RunBundler:
-    def __init__(self, md, record_interruptions, emit, emit_sync, log, *, strict_pre_declare=True):
+    def __init__(self, md, record_interruptions, emit, emit_sync, log, *, strict_pre_declare=False):
         # if create can YOLO implicitly create a stream
         self._strict_pre_declare = strict_pre_declare
         # state stolen from the RE

--- a/bluesky/plans.py
+++ b/bluesky/plans.py
@@ -73,7 +73,6 @@ def count(detectors, num=1, delay=None, *, per_shot=None, md=None):
     @bpp.stage_decorator(detectors)
     @bpp.run_decorator(md=_md)
     def inner_count():
-        # TODO thread stream name through per_shot?
         if predeclare:
             yield from bps.declare_stream(*detectors, name='primary')
         return (yield from bps.repeat(partial(per_shot, detectors),
@@ -524,7 +523,6 @@ def log_scan(detectors, motor, start, stop, num, *, per_step=None, md=None):
     @bpp.stage_decorator(list(detectors) + [motor])
     @bpp.run_decorator(md=_md)
     def inner_log_scan():
-        # TODO thread expected stream name through
         if predeclare:
             yield from bps.declare_stream(motor, *detectors, name='primary')
         for step in steps:
@@ -1007,7 +1005,6 @@ def scan_nd(detectors, cycler, *, per_step=None, md=None):
     @bpp.stage_decorator(list(detectors) + motors)
     @bpp.run_decorator(md=_md)
     def inner_scan_nd():
-        # TODO thread expected stream name through
         if predeclare:
             yield from bps.declare_stream(*motors, *detectors, name='primary')
         for step in list(cycler):

--- a/bluesky/run_engine.py
+++ b/bluesky/run_engine.py
@@ -450,6 +450,7 @@ class RunEngine:
         self._status_tasks = deque()  # from self._status_object_completed
         self._pardon_failures = None  # will hold an asyncio.Event
         self._plan = None  # the plan instance from __call__
+        self._require_stream_declaration = False
         self._command_registry = {
             'declare_stream': self._declare_stream,
             'create': self._create,
@@ -1775,7 +1776,8 @@ class RunEngine:
         self.md_validator(dict(md))
 
         current_run = self._run_bundlers[run_key] = type(self).RunBundler(
-            md, self.record_interruptions, self.emit, self.emit_sync, self.log
+            md, self.record_interruptions, self.emit, self.emit_sync, self.log,
+            strict_pre_declare=self._require_stream_declaration
         )
 
         new_uid = await current_run.open_run(msg)

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -709,3 +709,15 @@ def test_per_step(RE, hw):
     with pytest.raises(TypeError) as excinfo:
         RE(scan([hw.det], hw.motor, -1, 1, 3, per_step=bad_sig))
     assert excinfo.match("per_step must be a callable with the signature")
+
+
+def test_custom_stream_name(RE, hw):
+
+    def new_trigger_and_read(devices):
+        return (yield from trigger_and_read(devices, name='secondary'))
+
+    def new_per_step(detectors, motor, step):
+        return (yield from one_1d_step(detectors, motor,
+                                       step, take_reading=new_trigger_and_read))
+
+    RE(scan([hw.det], hw.motor, -1, 1, 3, per_step=new_per_step))

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -37,6 +37,7 @@ from bluesky.plan_stubs import (
     repeater,
     caching_repeater,
     repeat,
+    one_shot,
     one_1d_step,
     one_nd_step)
 from bluesky.preprocessors import (
@@ -59,7 +60,7 @@ from bluesky.plans import count, scan, rel_scan, inner_product_scan
 
 import bluesky.plans as bp
 
-from bluesky.utils import all_safe_rewind
+from bluesky.utils import all_safe_rewind, IllegalMessageSequence
 
 import threading
 
@@ -720,4 +721,15 @@ def test_custom_stream_name(RE, hw):
         return (yield from one_1d_step(detectors, motor,
                                        step, take_reading=new_trigger_and_read))
 
+    def new_per_shot(detectors):
+        return (yield from one_shot(detectors, take_reading=new_trigger_and_read))
+
     RE(scan([hw.det], hw.motor, -1, 1, 3, per_step=new_per_step))
+    RE(count([hw.det], 3, per_shot=new_per_shot))
+
+    RE._require_stream_declaration = True
+    with pytest.raises(IllegalMessageSequence):
+        RE(scan([hw.det], hw.motor, -1, 1, 3, per_step=new_per_step))
+
+    with pytest.raises(IllegalMessageSequence):
+        RE(count([hw.det], 3, per_shot=new_per_shot))

--- a/bluesky/tests/test_new_examples.py
+++ b/bluesky/tests/test_new_examples.py
@@ -733,3 +733,6 @@ def test_custom_stream_name(RE, hw):
 
     with pytest.raises(IllegalMessageSequence):
         RE(count([hw.det], 3, per_shot=new_per_shot))
+
+    with pytest.raises(IllegalMessageSequence):
+        RE(count([hw.det], 3, per_shot=one_shot))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updates stream declaration branch to answer outstanding questions in the main Bluesky PR

## Description
<!--- Describe your changes in detail -->
* scan_nd and count only pre-declare a stream if per_step is not passed in by the user, as the user may use a different stream name
* _strict_stream_declaration attribute added to RunEngine so that strict pre-declaration can be turned on and off (off by default)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Added a test that it is possible to implicitly declare a stream via per_step if strict checking is off
* Added a test that implicit stream declaration fails if strict checking is on
